### PR TITLE
アーカイブページのURLをarchive/index.htmlに統一

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -10,7 +10,7 @@
     <div class="collapse navbar-collapse target">
         <ul class="nav-list">
             <li {% if page.url == '/index.html' %}class="active"{% endif %}><a href="{{ site.base-url }}">Home</a></li>
-            <li {% if page.url == '/archive/index.html' %}class="active"{% endif %}><a href="{{ site.base-url }}archive">Archive</a></li>
+            <li {% if page.url == '/archive/index.html' %}class="active"{% endif %}><a href="{{ site.base-url }}archive/index.html">Archive</a></li>
             <li><a href="https://github.com/vim-jp/reading-vimrc/wiki/Request">Request</a></li>
             <li><a href="http://lingr.com/room/vim">Lingr - Vim部屋</a></li>
         </ul>


### PR DESCRIPTION
#1 のプルリクエストでナビゲーションバーのアーカイブページへのリンクが`archive/`になっていて元の`archive/index.html`と統一できていなかったのを修正
