### PR TITLE
ページタイトルのリンク先がすべてトップページになっているのを修正

### DIFF
--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -25,7 +25,7 @@
 
       <section>
         <div id="title">
-          <a href="{{ site.base-url }}"><h1>{% if page.title %}{{ page.title }}{% endif %}</h1></a>
+          <a href="{{ site.base-url }}{{ page.url | remove_first:'/' }}"><h1>{% if page.title %}{{ page.title }}{% endif %}</h1></a>
           <p></p>
           <hr>
         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,11 @@
 
       <section>
         <div id="title">
-          <a href="{{ site.base-url }}"><h1>{% if page.title %}{{ page.title }}{% endif %}</h1></a>
+          {% if page.url == '/index.html' %}
+              <a href="{{ site.base-url }}{{ page.url | remove_first:'/' | replace:'index.html','' }}"><h1>{% if page.title %}{{ page.title }}{% endif %}</h1></a>
+          {% else %}
+              <a href="{{ site.base-url }}{{ page.url | remove_first:'/' }}"><h1>{% if page.title %}{{ page.title }}{% endif %}</h1></a>
+          {% endif %}
           <p></p>
           <hr>
         </div>


### PR DESCRIPTION
各ページのタイトルのリンク先はトップページでなくそのページ自体へのリンクにしないと、ページタイトルの文言と噛み合わないので修正。

下記のページなどで確認できます。(マージ or クローズされたら消します)

http://haya14busa.github.io/reading-vimrc/archive/001.html
