### PR TITLE
fix: move the duplicate 730 to 731

### DIFF
--- a/_data/archives.yml
+++ b/_data/archives.yml
@@ -104119,8 +104119,8 @@
     - Omochice
     - thinca
   log: https://matrix.to/#/#vim-jp_reading-vimrc:gitter.im/$wrfBTp5ZQOJRNBBlA1lC78Q4TDUD1_k2ESNArGClRfM
-- id: 730
-  date: 2026-07-04 23:00
+- id: 731
+  date: 2026-07-11 23:00
   author:
     name: senioria
     url: https://github.com/senioria

--- a/archive/731.md
+++ b/archive/731.md
@@ -1,0 +1,7 @@
+---
+layout: archive
+title: 第731回 vimrc読書会
+id: 731
+category: archive
+---
+{% include archive.md %}


### PR DESCRIPTION
## Summary

Move the duplicate part 730 to part 731.

## Details

SSIA.

## Confirmation

There are no duplicates in the last 10 IDs.

```ts
import { parse } from "jsr:@std/yaml@1.1.2";

const t = parse(Deno.readTextFileSync("_data/archives.yml"));

console.log(t.slice(-10).map(({ id }) => id));
```

```json
[
  724, 725, 726, 727,
  728, 729, 730, 731,
  732, 733
]
```

## Limitation

None.
